### PR TITLE
fix(spec): update lab-04 frontend deploy hint

### DIFF
--- a/specs/lab-04.yaml
+++ b/specs/lab-04.yaml
@@ -456,8 +456,9 @@ checks:
     weight: 4
     depends_on: [task1_deployment_docs]
     hint: >
-      Build the frontend with 'npm run build' and deploy the dist/ folder
-      to your VM. Caddy should serve the static files at the root URL.
+      Rebuild the Caddy container on your VM with
+      'docker compose --env-file .env.docker.secret up --build caddy -d'.
+      Caddy serves the frontend at the root URL (http://<vm-ip>:<api-port>/).
     params:
       runtime: prod
       path: "/"


### PR DESCRIPTION
## Summary
- Update `task3_frontend_deployed` hint to reference `docker compose up --build caddy` instead of the old `npm run build` + `scp dist/` workflow.

Companion to inno-se-toolkit/se-toolkit-lab-4#25.