### PR TITLE
fix(spec): correct lab-04 status code and hints

### DIFF
--- a/specs/lab-04.yaml
+++ b/specs/lab-04.yaml
@@ -335,7 +335,7 @@ checks:
     params:
       runtime: prod
       path: "/interactions/"
-      expect_status: 401
+      expect_status: 403
 
   - id: task2_issue_has_linked_pr
     task: task-2
@@ -456,8 +456,9 @@ checks:
     weight: 4
     depends_on: [task1_deployment_docs]
     hint: >
-      Build the frontend with 'npm run build' and deploy the dist/ folder
-      to your VM. Caddy should serve the static files at the root URL.
+      Rebuild the Caddy container on your VM with
+      'docker compose --env-file .env.docker.secret up --build caddy -d'.
+      Caddy serves the frontend at the root URL (http://<vm-ip>:<api-port>/).
     params:
       runtime: prod
       path: "/"


### PR DESCRIPTION
## Summary
- `task2_interactions_deployed`: Fix `expect_status` from 401 to **403**. `HTTPBearer(auto_error=True)` returns 403 when no `Authorization` header is present.
- `task3_frontend_deployed`: Update hint to reference Docker rebuild workflow (supersedes #10).

## Test plan
- [ ] Run autochecker against a deployed student VM — `/interactions/` without auth should return 403.