### PR TITLE
feat: allow students to change VM IP + validate subnet

### DIFF
--- a/bot/handlers/check.py
+++ b/bot/handlers/check.py
@@ -10,13 +10,12 @@ from aiogram.fsm.context import FSMContext
 from aiogram.fsm.state import State, StatesGroup
 
 from ..database import User, get_attempts_count, add_attempt, save_result, get_server_ip, get_server_ip_owner, set_server_ip
+from ..ip_utils import validate_ip
 from ..keyboards import get_tasks_keyboard
 from ..runner import run_check
 from ..config import MAX_ATTEMPTS_PER_TASK, get_tasks_needing_ip
 
 router = Router()
-
-IP_RE = re.compile(r"^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$")
 
 
 class CheckStates(StatesGroup):
@@ -198,11 +197,9 @@ async def process_server_ip(message: Message, db_user: User, state: FSMContext) 
     """Handle server IP input, save it, and run the check."""
     ip = message.text.strip() if message.text else ""
 
-    if not IP_RE.match(ip):
-        await message.answer(
-            "That doesn't look like a valid IP address.\n"
-            "Please send just the IP (e.g., <code>10.90.138.42</code>):"
-        )
+    valid, error_msg = validate_ip(ip)
+    if not valid:
+        await message.answer(error_msg)
         return
 
     # Check uniqueness — each student must have their own VM IP

--- a/bot/handlers/labs.py
+++ b/bot/handlers/labs.py
@@ -1,12 +1,19 @@
-"""Handler for lab selection callbacks."""
+"""Handler for lab selection and VM IP change callbacks."""
 
 from aiogram import Router, F
-from aiogram.types import CallbackQuery
+from aiogram.types import CallbackQuery, Message
+from aiogram.fsm.context import FSMContext
+from aiogram.fsm.state import State, StatesGroup
 
-from ..database import User
+from ..database import User, get_server_ip, get_server_ip_owner, set_server_ip
+from ..ip_utils import validate_ip
 from ..keyboards import get_labs_keyboard, get_tasks_keyboard
 
 router = Router()
+
+
+class ChangeIPStates(StatesGroup):
+    waiting_for_new_ip = State()
 
 
 @router.callback_query(F.data.startswith("lab:"))
@@ -21,10 +28,69 @@ async def callback_select_lab(callback: CallbackQuery, db_user: User) -> None:
 
 
 @router.callback_query(F.data == "back_to_labs")
-async def callback_back_to_labs(callback: CallbackQuery) -> None:
+async def callback_back_to_labs(callback: CallbackQuery, db_user: User) -> None:
     """Return to the lab selection menu."""
     await callback.answer()
+    server_ip = await get_server_ip(db_user.tg_id)
     await callback.message.edit_text(
         "Choose a lab:",
-        reply_markup=get_labs_keyboard(),
+        reply_markup=get_labs_keyboard(server_ip=server_ip),
+    )
+
+
+@router.callback_query(F.data == "change_ip")
+async def callback_change_ip(callback: CallbackQuery, db_user: User, state: FSMContext) -> None:
+    """Show student profile and prompt for new VM IP."""
+    current_ip = await get_server_ip(db_user.tg_id)
+
+    # Build profile info
+    profile_lines = [
+        "<b>Your profile:</b>",
+        f"  GitHub: <code>{db_user.github_alias}</code>",
+        f"  Email: <code>{db_user.email}</code>",
+        f"  VM IP: <code>{current_ip}</code>" if current_ip else "  VM IP: not set",
+    ]
+    profile = "\n".join(profile_lines)
+
+    if current_ip:
+        prompt = (
+            f"{profile}\n\n"
+            "Send the new IP address (e.g., <code>10.93.25.100</code>),\n"
+            "or /start to cancel:"
+        )
+    else:
+        prompt = (
+            f"{profile}\n\n"
+            "Send your VM IP address (e.g., <code>10.93.25.100</code>),\n"
+            "or /start to cancel:"
+        )
+    await callback.answer()
+    await callback.message.edit_text(prompt)
+    await state.set_state(ChangeIPStates.waiting_for_new_ip)
+
+
+@router.message(ChangeIPStates.waiting_for_new_ip)
+async def process_change_ip(message: Message, db_user: User, state: FSMContext) -> None:
+    """Validate and save the new VM IP, then return to labs menu."""
+    ip = message.text.strip() if message.text else ""
+
+    valid, error_msg = validate_ip(ip)
+    if not valid:
+        await message.answer(error_msg)
+        return
+
+    existing_owner = await get_server_ip_owner(ip, db_user.tg_id)
+    if existing_owner:
+        await message.answer(
+            "This IP is already registered to another student.\n"
+            "Each student must use their own VM. Please enter your unique VM IP:"
+        )
+        return
+
+    await set_server_ip(db_user.tg_id, ip)
+    await state.clear()
+
+    await message.answer(
+        f"VM IP updated to <code>{ip}</code>\n\nChoose a lab:",
+        reply_markup=get_labs_keyboard(server_ip=ip),
     )

--- a/bot/handlers/start.py
+++ b/bot/handlers/start.py
@@ -7,7 +7,7 @@ from aiogram.filters import CommandStart, BaseFilter
 from aiogram.types import Message, TelegramObject
 from aiogram.fsm.context import FSMContext
 
-from ..database import User
+from ..database import User, get_server_ip
 from ..keyboards import get_labs_keyboard
 
 router = Router()
@@ -24,10 +24,11 @@ class IsRegistered(BaseFilter):
 async def cmd_start(message: Message, db_user: User, state: FSMContext) -> None:
     """Handle /start command for registered users — clear any FSM state and show task list."""
     await state.clear()
+    server_ip = await get_server_ip(db_user.tg_id)
     await message.answer(
         f"Welcome, {db_user.github_alias}!\n\n"
         "Choose a lab:",
-        reply_markup=get_labs_keyboard(),
+        reply_markup=get_labs_keyboard(server_ip=server_ip),
     )
 
 
@@ -35,7 +36,8 @@ async def cmd_start(message: Message, db_user: User, state: FSMContext) -> None:
 async def catch_all_registered(message: Message, db_user: User, state: FSMContext) -> None:
     """Catch any unrecognized message from a registered user — show labs menu."""
     await state.clear()
+    server_ip = await get_server_ip(db_user.tg_id)
     await message.answer(
         "Choose a lab:",
-        reply_markup=get_labs_keyboard(),
+        reply_markup=get_labs_keyboard(server_ip=server_ip),
     )

--- a/bot/ip_utils.py
+++ b/bot/ip_utils.py
@@ -1,0 +1,51 @@
+"""IP address validation for student VM IPs."""
+
+import re
+
+IP_RE = re.compile(r"^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$")
+
+
+def validate_ip(ip: str) -> tuple[bool, str | None]:
+    """Validate a VM IP address.
+
+    Returns (True, None) if valid, or (False, error_message) if invalid.
+    """
+    if not IP_RE.match(ip):
+        return False, (
+            "That doesn't look like a valid IP address.\n"
+            "Please send just the IP (e.g., <code>10.93.25.100</code>):"
+        )
+
+    octets = [int(o) for o in ip.split(".")]
+    if any(o > 255 for o in octets):
+        return False, (
+            "Invalid IP address — each octet must be 0-255.\n"
+            "Please enter a valid IP:"
+        )
+
+    # Reject reserved/dummy addresses
+    if (
+        ip == "0.0.0.0"
+        or ip == "255.255.255.255"
+        or octets[0] == 127          # loopback
+        or octets[0] >= 224          # multicast + reserved
+        or (octets[0] == 169 and octets[1] == 254)  # link-local
+    ):
+        return False, (
+            "This is a reserved IP address and cannot be used.\n"
+            "Please enter your actual VM IP:"
+        )
+
+    # Internal 10.x.x.x — must be 10.93.x.x
+    if octets[0] == 10:
+        if octets[1] != 93:
+            return False, (
+                "Internal IPs must be from the <b>10.93.x.x</b> subnet.\n\n"
+                'VMs under the "Software Engineering Toolkit" subscription '
+                "are created in the 10.93.x.x network. If your VM has a "
+                "different subnet, it was created under a different subscription. "
+                'Please create your VM under the "Software Engineering Toolkit" '
+                "subscription."
+            )
+
+    return True, None

--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -7,14 +7,16 @@ from .config import get_active_tasks, get_lab_titles, MAX_ATTEMPTS_PER_TASK
 from .database import get_task_stats, has_passed_task
 
 
-def get_labs_keyboard() -> InlineKeyboardMarkup:
-    """Create inline keyboard with available labs."""
+def get_labs_keyboard(server_ip: str = "") -> InlineKeyboardMarkup:
+    """Create inline keyboard with available labs + VM IP button."""
     builder = InlineKeyboardBuilder()
     for lab_id, title in get_lab_titles().items():
         builder.add(
             InlineKeyboardButton(text=title, callback_data=f"lab:{lab_id}")
         )
     builder.adjust(1)
+    ip_label = f"VM: {server_ip}" if server_ip else "Set VM IP"
+    builder.row(InlineKeyboardButton(text=ip_label, callback_data="change_ip"))
     return builder.as_markup()
 
 


### PR DESCRIPTION
## Summary
- Adds a **"VM: x.x.x.x"** (or "Set VM IP") button to the labs keyboard so students can change their IP at any time
- Shows student profile (GitHub alias, email, current IP) when clicking the button
- Shared IP validation (`bot/ip_utils.py`):
  - Rejects dummy/reserved IPs (loopback, link-local, multicast, broadcast)
  - Internal `10.x.x.x` must be `10.93.x.x` — wrong subnet gives a helpful message about creating the VM under the "Software Engineering Toolkit" subscription
  - Public IPs are accepted
- Same validation applied to existing first-time IP prompt in check flow

Closes #12

## Test plan
- [ ] `/start` → labs menu shows "Set VM IP" button at bottom
- [ ] Click "Set VM IP" → shows profile info + prompt
- [ ] Enter `10.90.5.5` → rejected with subscription message
- [ ] Enter `127.0.0.1` → rejected as reserved
- [ ] Enter `10.93.25.100` → accepted, button updates to "VM: 10.93.25.100"
- [ ] Click "VM: 10.93.25.100" → shows current profile, allows changing
- [ ] Enter public IP like `188.245.43.68` → accepted
- [ ] Run a task check needing IP → works with stored IP
- [ ] `/start` cancels IP input and returns to labs menu