### PR TITLE
fix: allow /start during FSM input states

### DIFF
--- a/bot/handlers/check.py
+++ b/bot/handlers/check.py
@@ -11,7 +11,7 @@ from aiogram.fsm.state import State, StatesGroup
 
 from ..database import User, get_attempts_count, add_attempt, save_result, get_server_ip, get_server_ip_owner, set_server_ip
 from ..ip_utils import validate_ip
-from ..keyboards import get_tasks_keyboard
+from ..keyboards import get_labs_keyboard, get_tasks_keyboard
 from ..runner import run_check
 from ..config import MAX_ATTEMPTS_PER_TASK, get_tasks_needing_ip
 
@@ -195,15 +195,24 @@ async def callback_check_task(callback: CallbackQuery, db_user: User, state: FSM
 @router.message(CheckStates.waiting_for_server_ip)
 async def process_server_ip(message: Message, db_user: User, state: FSMContext) -> None:
     """Handle server IP input, save it, and run the check."""
-    ip = message.text.strip() if message.text else ""
+    text = message.text.strip() if message.text else ""
 
-    valid, error_msg = validate_ip(ip)
+    if text.startswith("/"):
+        await state.clear()
+        server_ip = await get_server_ip(db_user.tg_id)
+        await message.answer(
+            "Cancelled.\n\nChoose a lab:",
+            reply_markup=get_labs_keyboard(server_ip=server_ip),
+        )
+        return
+
+    valid, error_msg = validate_ip(text)
     if not valid:
         await message.answer(error_msg)
         return
 
     # Check uniqueness — each student must have their own VM IP
-    existing_owner = await get_server_ip_owner(ip, db_user.tg_id)
+    existing_owner = await get_server_ip_owner(text, db_user.tg_id)
     if existing_owner:
         await message.answer(
             f"This IP is already registered to another student.\n"
@@ -212,7 +221,7 @@ async def process_server_ip(message: Message, db_user: User, state: FSMContext) 
         return
 
     # Save IP and clear FSM state
-    await set_server_ip(db_user.tg_id, ip)
+    await set_server_ip(db_user.tg_id, text)
     data = await state.get_data()
     await state.clear()
 

--- a/bot/handlers/labs.py
+++ b/bot/handlers/labs.py
@@ -72,14 +72,23 @@ async def callback_change_ip(callback: CallbackQuery, db_user: User, state: FSMC
 @router.message(ChangeIPStates.waiting_for_new_ip)
 async def process_change_ip(message: Message, db_user: User, state: FSMContext) -> None:
     """Validate and save the new VM IP, then return to labs menu."""
-    ip = message.text.strip() if message.text else ""
+    text = message.text.strip() if message.text else ""
 
-    valid, error_msg = validate_ip(ip)
+    if text.startswith("/"):
+        await state.clear()
+        server_ip = await get_server_ip(db_user.tg_id)
+        await message.answer(
+            "Cancelled.\n\nChoose a lab:",
+            reply_markup=get_labs_keyboard(server_ip=server_ip),
+        )
+        return
+
+    valid, error_msg = validate_ip(text)
     if not valid:
         await message.answer(error_msg)
         return
 
-    existing_owner = await get_server_ip_owner(ip, db_user.tg_id)
+    existing_owner = await get_server_ip_owner(text, db_user.tg_id)
     if existing_owner:
         await message.answer(
             "This IP is already registered to another student.\n"
@@ -87,10 +96,10 @@ async def process_change_ip(message: Message, db_user: User, state: FSMContext) 
         )
         return
 
-    await set_server_ip(db_user.tg_id, ip)
+    await set_server_ip(db_user.tg_id, text)
     await state.clear()
 
     await message.answer(
-        f"VM IP updated to <code>{ip}</code>\n\nChoose a lab:",
-        reply_markup=get_labs_keyboard(server_ip=ip),
+        f"VM IP updated to <code>{text}</code>\n\nChoose a lab:",
+        reply_markup=get_labs_keyboard(server_ip=text),
     )


### PR DESCRIPTION
## Summary
- When a user is in an FSM state (waiting for VM IP input), sending `/start` was caught by the FSM handler instead of the `/start` command handler, causing "invalid input" errors
- Now any `/command` during IP input cancels the operation and returns to the labs menu
- Fixed in both `check.py` (first-time IP prompt) and `labs.py` (change IP flow)

## Test plan
- [ ] Start a check that prompts for IP → send `/start` → should cancel and show labs menu
- [ ] Click "Change IP" → send `/start` → should cancel and show labs menu
- [ ] Normal IP input still works in both flows

Closes #18