### PR TITLE
Fix lab 7 handling

### DIFF
--- a/bot/config.py
+++ b/bot/config.py
@@ -126,7 +126,13 @@ def get_max_attempts(lab_id: str, task_id: str) -> int:
 
 
 def get_tasks_needing_lms_key(lab_id: str) -> set[str]:
-    """Return task IDs that have agent_eval checks (need LMS_API_KEY)."""
+    """Return task IDs that need the student's LMS_API_KEY.
+
+    Controlled by the top-level ``requires_lms_key`` flag in the lab spec:
+      - ``true``  → all tasks in the lab require the key
+      - ``false`` → no tasks require the key
+      - omitted   → auto-detect from check types (agent_eval)
+    """
     spec_path = SPECS_DIR / f"{lab_id}.yaml"
     if not spec_path.exists():
         return set()
@@ -134,6 +140,14 @@ def get_tasks_needing_lms_key(lab_id: str) -> set[str]:
     with open(spec_path, "r", encoding="utf-8") as f:
         spec = yaml.safe_load(f)
 
+    # Explicit override takes precedence
+    explicit = spec.get("requires_lms_key")
+    if explicit is True:
+        return {task["id"] for task in spec.get("tasks", [])}
+    if explicit is False:
+        return set()
+
+    # Default: auto-detect from agent_eval checks
     task_ids: set[str] = set()
     for check in spec.get("checks", []):
         if check.get("type") == "agent_eval":

--- a/bot/handlers/check.py
+++ b/bot/handlers/check.py
@@ -562,17 +562,19 @@ async def process_vm_username(message: Message, db_user: User, state: FSMContext
     task_id = data["task_id"]
 
     # Now check if we also need LMS_API_KEY
-    lms_api_key = await get_lms_api_key(db_user.tg_id)
-    if not lms_api_key:
-        await state.update_data(lab_id=lab_id, task_id=task_id)
-        await state.set_state(CheckStates.waiting_for_lms_key)
-        await message.answer(
-            f"Saved VM username: <code>{text}</code>\n\n"
-            f"Now I need your <code>LMS_API_KEY</code> "
-            f"(the backend API key from your <code>.env.docker.secret</code>).\n\n"
-            f"Reply with your LMS_API_KEY:",
-        )
-        return
+    lms_api_key = ""
+    if task_id in get_tasks_needing_lms_key(lab_id):
+        lms_api_key = await get_lms_api_key(db_user.tg_id)
+        if not lms_api_key:
+            await state.update_data(lab_id=lab_id, task_id=task_id)
+            await state.set_state(CheckStates.waiting_for_lms_key)
+            await message.answer(
+                f"Saved VM username: <code>{text}</code>\n\n"
+                f"Now I need your <code>LMS_API_KEY</code> "
+                f"(the backend API key from your <code>.env.docker.secret</code>).\n\n"
+                f"Reply with your LMS_API_KEY:",
+            )
+            return
 
     await state.clear()
 

--- a/bot/handlers/check.py
+++ b/bot/handlers/check.py
@@ -19,7 +19,7 @@ from ..database import User, get_attempts_count, add_attempt, save_result, get_s
 from ..ip_utils import validate_ip
 from ..keyboards import get_labs_keyboard, get_tasks_keyboard
 from ..runner import run_check
-from ..config import MAX_ATTEMPTS_PER_TASK, get_max_attempts, get_tasks_needing_ip, get_tasks_needing_lms_key, get_tasks_needing_vm_username
+from ..config import MAX_ATTEMPTS_PER_TASK, ACTIVE_LABS, get_max_attempts, get_tasks_needing_ip, get_tasks_needing_lms_key, get_tasks_needing_vm_username
 
 router = Router()
 
@@ -96,9 +96,11 @@ async def cmd_reset(message: Message, db_user: User, state: FSMContext) -> None:
 
     await state.clear()
 
+    any_lab_needs_lms = any(get_tasks_needing_lms_key(lab) for lab in ACTIVE_LABS)
+
     server_ip = await get_server_ip(db_user.tg_id)
     vm_user = await get_vm_username(db_user.tg_id)
-    lms_key = await get_lms_api_key(db_user.tg_id)
+    lms_key = await get_lms_api_key(db_user.tg_id) if any_lab_needs_lms else ""
 
     lines = ["<b>Your stored settings:</b>\n"]
     buttons = []
@@ -115,11 +117,12 @@ async def cmd_reset(message: Message, db_user: User, state: FSMContext) -> None:
     else:
         lines.append("VM username: <i>not set</i>")
 
-    if lms_key:
-        lines.append(f"LMS API key: <code>{lms_key[:6]}...</code>")
-        buttons.append([InlineKeyboardButton(text="Reset LMS API key", callback_data="reset:lms_api_key")])
-    else:
-        lines.append("LMS API key: <i>not set</i>")
+    if any_lab_needs_lms:
+        if lms_key:
+            lines.append(f"LMS API key: <code>{lms_key[:6]}...</code>")
+            buttons.append([InlineKeyboardButton(text="Reset LMS API key", callback_data="reset:lms_api_key")])
+        else:
+            lines.append("LMS API key: <i>not set</i>")
 
     if not buttons:
         lines.append("\nNothing to reset.")
@@ -148,10 +151,12 @@ async def callback_reset(callback: CallbackQuery, db_user: User) -> None:
         await callback.answer("Unknown setting.", show_alert=True)
         return
 
+    any_lab_needs_lms = any(get_tasks_needing_lms_key(lab) for lab in ACTIVE_LABS)
+
     # Refresh the message
     server_ip = await get_server_ip(db_user.tg_id)
     vm_user = await get_vm_username(db_user.tg_id)
-    lms_key = await get_lms_api_key(db_user.tg_id)
+    lms_key = await get_lms_api_key(db_user.tg_id) if any_lab_needs_lms else ""
 
     lines = ["<b>Your stored settings:</b>\n"]
     buttons = []
@@ -168,11 +173,12 @@ async def callback_reset(callback: CallbackQuery, db_user: User) -> None:
     else:
         lines.append("VM username: <i>not set</i>")
 
-    if lms_key:
-        lines.append(f"LMS API key: <code>{lms_key[:6]}...</code>")
-        buttons.append([InlineKeyboardButton(text="Reset LMS API key", callback_data="reset:lms_api_key")])
-    else:
-        lines.append("LMS API key: <i>not set</i>")
+    if any_lab_needs_lms:
+        if lms_key:
+            lines.append(f"LMS API key: <code>{lms_key[:6]}...</code>")
+            buttons.append([InlineKeyboardButton(text="Reset LMS API key", callback_data="reset:lms_api_key")])
+        else:
+            lines.append("LMS API key: <i>not set</i>")
 
     if not buttons:
         lines.append("\nAll settings cleared.")

--- a/specs/lab-07.yaml
+++ b/specs/lab-07.yaml
@@ -11,6 +11,8 @@ scoring:
   pass_threshold: 0.75
   score_required_only: true
 
+requires_lms_key: false
+
 tasks:
   - id: setup
     title: "Lab setup"
@@ -32,6 +34,8 @@ checks:
   # =====================================================
   # SETUP — repo, VM, env files, backend, LLM
   # =====================================================
+
+# TODO issue title
 
   - id: repo_exists
     task: setup

--- a/specs/lab-07.yaml
+++ b/specs/lab-07.yaml
@@ -97,7 +97,16 @@ checks:
     params:
       runtime: prod
       username: __vm_username__
-      command: "test -d ~/se-toolkit-lab-7/.git && test -f ~/se-toolkit-lab-7/.env.docker.secret && grep -q BOT_TOKEN ~/se-toolkit-lab-7/.env.bot.secret && grep -q LMS_API_KEY ~/se-toolkit-lab-7/.env.bot.secret && echo ok"
+      command: >
+        OK=1;
+        test -d ~/se-toolkit-lab-7/.git || { echo "missing: ~/se-toolkit-lab-7/.git directory"; OK=0; };
+        test -f ~/se-toolkit-lab-7/.env.docker.secret || { echo "missing: .env.docker.secret"; OK=0; };
+        test -f ~/se-toolkit-lab-7/.env.bot.secret || { echo "missing: .env.bot.secret"; OK=0; };
+        if [ -f ~/se-toolkit-lab-7/.env.bot.secret ]; then
+        grep -q BOT_TOKEN ~/se-toolkit-lab-7/.env.bot.secret || { echo "missing: BOT_TOKEN in .env.bot.secret"; OK=0; };
+        grep -q LMS_API_KEY ~/se-toolkit-lab-7/.env.bot.secret || { echo "missing: LMS_API_KEY in .env.bot.secret"; OK=0; };
+        fi;
+        [ "$OK" = "1" ] && echo ok
       expect_regex: "ok"
       timeout: 10
 
@@ -116,7 +125,16 @@ checks:
     params:
       runtime: prod
       username: __vm_username__
-      command: "LMS_KEY=$(grep LMS_API_KEY ~/se-toolkit-lab-7/.env.bot.secret | cut -d= -f2); curl -sf http://localhost:42002/items/ -H \"Authorization: Bearer $LMS_KEY\" | python3 -c 'import sys,json; items=json.load(sys.stdin); exit(0 if len(items)>0 else 1)' 2>/dev/null && echo ok || echo fail"
+      command: >
+        LMS_KEY=$(grep '^LMS_API_KEY=' ~/se-toolkit-lab-7/.env.bot.secret | cut -d= -f2- | tr -d '"'"'"' ');
+        if [ -z "$LMS_KEY" ]; then echo "fail: LMS_API_KEY not found in .env.bot.secret"; exit 0; fi;
+        HTTP=$(curl -s -o /tmp/_ac_items -w '%{http_code}' http://localhost:42002/items/ -H "Authorization: Bearer $LMS_KEY");
+        if [ "$HTTP" = "000" ]; then echo "fail: connection refused on port 42002 (is docker running?)"; exit 0; fi;
+        if [ "$HTTP" != "200" ]; then echo "fail: backend returned HTTP $HTTP"; exit 0; fi;
+        COUNT=$(python3 -c 'import sys,json; print(len(json.load(sys.stdin)))' < /tmp/_ac_items 2>&1);
+        if ! echo "$COUNT" | grep -qE '^[0-9]+$'; then echo "fail: could not parse response: $COUNT"; exit 0; fi;
+        if [ "$COUNT" = "0" ]; then echo "fail: backend returned 0 items (run pipeline/sync first)"; exit 0; fi;
+        echo ok
       expect_regex: "ok"
       timeout: 15
 
@@ -135,7 +153,17 @@ checks:
     params:
       runtime: prod
       username: __vm_username__
-      command: "LLM_KEY=$(grep LLM_API_KEY ~/se-toolkit-lab-7/.env.bot.secret | cut -d= -f2); curl -sf http://localhost:42005/v1/models -H \"Authorization: Bearer $LLM_KEY\" | python3 -c 'import sys,json; d=json.load(sys.stdin); print(len(d.get(\"data\",[])))' 2>/dev/null || echo 0"
+      command: >
+        LLM_KEY=$(grep '^LLM_API_KEY=' ~/se-toolkit-lab-7/.env.bot.secret | cut -d= -f2- | tr -d '"'"'"' ');
+        if [ -z "$LLM_KEY" ]; then echo "0 (LLM_API_KEY not found in .env.bot.secret)"; exit 0; fi;
+        HTTP=$(curl -s -o /tmp/_ac_llm -w '%{http_code}' http://localhost:42005/v1/models -H "Authorization: Bearer $LLM_KEY");
+        if [ "$HTTP" = "000" ]; then echo "0 (connection refused on port 42005 — is qwen proxy running?)"; exit 0; fi;
+        if [ "$HTTP" = "401" ]; then echo "0 (HTTP 401 — token expired, restart proxy: cd ~/qwen-code-oai-proxy && docker compose restart)"; exit 0; fi;
+        if [ "$HTTP" != "200" ]; then echo "0 (proxy returned HTTP $HTTP)"; exit 0; fi;
+        COUNT=$(python3 -c 'import sys,json; d=json.load(sys.stdin); print(len(d.get("data",[])))' < /tmp/_ac_llm 2>&1);
+        if ! echo "$COUNT" | grep -qE '^[0-9]+$'; then echo "0 (failed to parse response: $COUNT)"; exit 0; fi;
+        if [ "$COUNT" = "0" ]; then echo "0 (proxy returned 0 models — token may be expired)"; exit 0; fi;
+        echo $COUNT
       expect_regex: "^[1-9]"
       timeout: 15
 
@@ -395,8 +423,12 @@ checks:
         TOOLS=$(grep -r '"type".*:.*"function"' bot/ 2>/dev/null | wc -l) &&
         BUTTONS=$(grep -ri 'keyboard\|CallbackQuery' bot/ 2>/dev/null | wc -l) &&
         REGEX_ROUTING=$(grep -rn 're\.search\|re\.match\|INTENT_PATTERN' bot/handlers/ 2>/dev/null | grep -v test | grep -v '#' | wc -l) &&
-        echo "tools:$TOOLS buttons:$BUTTONS regex_routing:$REGEX_ROUTING" &&
-        test $TOOLS -ge 9 && test $BUTTONS -ge 1 && test $REGEX_ROUTING -eq 0 && echo PASS || echo FAIL
+        echo "tools:$TOOLS buttons:$BUTTONS regex_routing:$REGEX_ROUTING";
+        FAIL="";
+        test $TOOLS -ge 9 || FAIL="${FAIL} tools<9(found $TOOLS)";
+        test $BUTTONS -ge 1 || FAIL="${FAIL} no_keyboard/callback_buttons";
+        test $REGEX_ROUTING -eq 0 || FAIL="${FAIL} regex_routing_found($REGEX_ROUTING matches)";
+        [ -z "$FAIL" ] && echo PASS || echo "FAIL:$FAIL"
       expect_regex: "PASS"
       timeout: 15
 
@@ -460,6 +492,7 @@ checks:
       command: >
         export PATH=$HOME/.local/bin:$PATH && cd ~/se-toolkit-lab-7 &&
         APP_CONTAINER=$(docker ps --format '{{.Names}}' | grep -iE 'app|backend' | head -1) &&
+        if [ -z "$APP_CONTAINER" ]; then echo "FAIL: no running container matching 'app' or 'backend' found"; exit 0; fi &&
         BEFORE=$(docker logs $APP_CONTAINER 2>&1 | wc -l) &&
         cd bot &&
         uv run bot.py --test 'what labs are available' >/dev/null 2>&1 &&
@@ -516,10 +549,13 @@ checks:
         BOT_COMPOSE=$(grep -c 'bot:' docker-compose.yml 2>/dev/null || echo 0) &&
         BOT_RUNNING=$(docker ps --format '{{.Names}}' | grep -ci bot || echo 0) &&
         BACKEND=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:42002/docs) &&
-        echo "remote:$REMOTE compose:$BOT_COMPOSE running:$BOT_RUNNING backend:$BACKEND" &&
-        echo "$REMOTE" | grep -qi 'github.com.*se-toolkit-lab-7' &&
-        test $BOT_COMPOSE -ge 1 && test $BOT_RUNNING -ge 1 && test "$BACKEND" = "200" &&
-        echo PASS || echo FAIL
+        echo "remote:$REMOTE compose:$BOT_COMPOSE running:$BOT_RUNNING backend:$BACKEND";
+        FAIL="";
+        echo "$REMOTE" | grep -qi 'github.com.*se-toolkit-lab-7' || FAIL="${FAIL} remote_not_github";
+        test $BOT_COMPOSE -ge 1 || FAIL="${FAIL} no_bot_service_in_compose";
+        test $BOT_RUNNING -ge 1 || FAIL="${FAIL} bot_container_not_running";
+        test "$BACKEND" = "200" || FAIL="${FAIL} backend_unhealthy(HTTP_$BACKEND)";
+        [ -z "$FAIL" ] && echo PASS || echo "FAIL:$FAIL"
       expect_regex: "PASS"
       timeout: 30
 


### PR DESCRIPTION
- Replace opaque "fail"/"0"/"FAIL" outputs with specific error messages so students can see exactly what went wrong (missing keys, connection refused, HTTP errors, missing containers, etc.). 
- Anchor env var grep patterns and strip quotes to handle common .env formatting.
- Don't show `LMS_API_KEY` in the Autochecker Telegram bot when it's not used.