### PR TITLE
Bot UX and config improvements

### DIFF
--- a/autochecker/engine.py
+++ b/autochecker/engine.py
@@ -1507,11 +1507,22 @@ with open("_eval_results.json", "w") as f:
                     continue
 
                 if ao["rc"] != 0:
-                    stderr_preview = ao["stderr"][:100]
-                    results.append(
+                    stderr_preview = ao["stderr"][:200]
+                    exit_hints = {
+                        1: "unhandled exception",
+                        2: "syntax error, missing file, or bad CLI args",
+                        126: "agent.py is not executable",
+                        127: "uv or agent.py not found",
+                    }
+                    hint = exit_hints.get(ao["rc"], "")
+                    hint_suffix = f" ({hint})" if hint else ""
+                    msg = (
                         f"  x [{q['index']}] Agent exited with code "
-                        f"{ao['rc']}: {stderr_preview}"
+                        f"{ao['rc']}{hint_suffix}"
                     )
+                    if stderr_preview:
+                        msg += f": {stderr_preview}"
+                    results.append(msg)
                     continue
 
                 stdout = ao["stdout"]
@@ -1875,7 +1886,7 @@ with open("_eval_results.json", "w") as f:
                 f"set -a && . <(tr -d '\\r' < {env_agent_file}) && set +a && "
                 f"export LMS_API_KEY='{lms_api_key}' && "
                 f"export AGENT_API_BASE_URL='http://localhost:42002' && "
-                f"uv run agent.py '{escaped_q}' 2>/dev/null"
+                f"uv run agent.py '{escaped_q}'"
             )
 
             ok, result = self._ssh_check_via_relay(
@@ -1917,11 +1928,22 @@ with open("_eval_results.json", "w") as f:
                 continue
 
             if ao["rc"] != 0:
-                stderr_preview = ao["stderr"][:100]
-                results.append(
+                stderr_preview = ao["stderr"][:200]
+                exit_hints = {
+                    1: "unhandled exception",
+                    2: "syntax error, missing file, or bad CLI args",
+                    126: "agent.py is not executable",
+                    127: "uv or agent.py not found",
+                }
+                hint = exit_hints.get(ao["rc"], "")
+                hint_suffix = f" ({hint})" if hint else ""
+                msg = (
                     f"  x [{q['index']}] Agent exited with code "
-                    f"{ao['rc']}: {stderr_preview}"
+                    f"{ao['rc']}{hint_suffix}"
                 )
+                if stderr_preview:
+                    msg += f": {stderr_preview}"
+                results.append(msg)
                 continue
 
             stdout = ao["stdout"]


### PR DESCRIPTION
## Summary

- **Configurable requires_lms_key per lab**: new top-level flag in lab specs (true/false/omitted for auto-detect). Skips the LMS API key prompt for labs that dont need it (e.g. lab-07).
- **Skip LMS key prompt in vm_username handler**: only asks for LMS_API_KEY when the selected task actually requires it.
- **Informative agent eval error messages**: removed 2>/dev/null that was swallowing stderr, added human-readable hints for common exit codes (1=exception, 2=syntax error, 126=not executable, 127=not found), and increased stderr preview from 100 to 200 chars.

## Test plan
- [ ] Run a lab-07 check -- should not prompt for LMS API key
- [ ] Run a lab with requires_lms_key: true or omitted -- should still prompt for LMS API key
- [ ] Trigger an agent crash (e.g. syntax error in agent.py) -- error message should now show the exit code hint and stderr

Generated with Claude Code

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>