### PR TITLE
Fix report checks

### DIFF
--- a/specs/lab-08.yaml
+++ b/specs/lab-08.yaml
@@ -411,7 +411,7 @@ checks:
         import json, os, urllib.request
 
         base = os.path.expanduser("~/se-toolkit-lab-8")
-        report = open(os.path.join(base, "REPORT.md")).read()[:4000]
+        report = open(os.path.join(base, "REPORT.md")).read()
 
         # Read LLM API key
         api_key = None
@@ -433,7 +433,6 @@ checks:
         body = json.dumps({
             "model": "coder-model",
             "messages": [{"role": "user", "content": prompt + "\n\n" + report}],
-            "max_tokens": 100,
         }).encode()
 
         req = urllib.request.Request(
@@ -615,7 +614,7 @@ checks:
         import json, os, urllib.request
 
         base = os.path.expanduser("~/se-toolkit-lab-8")
-        report = open(os.path.join(base, "REPORT.md")).read()[:4000]
+        report = open(os.path.join(base, "REPORT.md")).read()
 
         api_key = None
         for line in open(os.path.join(base, ".env.docker.secret")):
@@ -636,7 +635,6 @@ checks:
         body = json.dumps({
             "model": "coder-model",
             "messages": [{"role": "user", "content": prompt + "\n\n" + report}],
-            "max_tokens": 100,
         }).encode()
 
         req = urllib.request.Request(
@@ -796,7 +794,7 @@ checks:
         import json, os, urllib.request
 
         base = os.path.expanduser("~/se-toolkit-lab-8")
-        report = open(os.path.join(base, "REPORT.md")).read()[:5000]
+        report = open(os.path.join(base, "REPORT.md")).read()
 
         api_key = None
         for line in open(os.path.join(base, ".env.docker.secret")):
@@ -819,7 +817,6 @@ checks:
         body = json.dumps({
             "model": "coder-model",
             "messages": [{"role": "user", "content": prompt + "\n\n" + report}],
-            "max_tokens": 100,
         }).encode()
 
         req = urllib.request.Request(


### PR DESCRIPTION
## Problem

Students write long reports and provide all nanobot logs.

LLM doesn't read student's report completely and produces a message like

```
Missing Task 1B and Task 1C sections entirely. Task 1A also lacks the pasted response regarding available labs.
```

### Solution

Remove limits on the input size

The coder-model's context size is 1M tokens.

We use student's subscription to check reports so no need to limit the context size

After the fix on the VM 10.93.25.152 (`bash /tmp/t1_report.sh`)

```
All three required sections (1A, 1B, 1C) contain actual pasted agent output with specific details (agentic loop text, real lab names like Lab 01/02, and the agent asking which lab to select).
```